### PR TITLE
Fixups to allow the proxy to use mock-dst

### DIFF
--- a/.github/dco.yml
+++ b/.github/dco.yml
@@ -1,0 +1,2 @@
+require:
+  members: false

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,7 +68,7 @@ impl DstService {
     ) -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
         let addr = addr.into();
         let span = tracing::info_span!("DstService::serve", listen.addr = %addr);
-        tracing::info!(parent: &span, "starting destination server...");
+        tracing::info!(parent: &span, "Starting destination server...");
 
         tonic::transport::Server::builder()
             .trace_fn(|headers| tracing::debug_span!("request", ?headers))
@@ -84,7 +84,7 @@ impl DstService {
     async fn stream_destination(&self, dst: &Dst) -> mpsc::Receiver<GrpcResult<Update>> {
         let state = self.state.read().await.get(dst).cloned();
         if let Some(mut state) = state {
-            tracing::info!(?dst, "exists");
+            tracing::info!("Serving endpoints");
             let (mut tx, rx) = mpsc::channel(8);
             tokio::spawn(
                 async move {
@@ -119,15 +119,15 @@ impl DstService {
                         }
                         prev = curr;
                     }
-                    tracing::debug!("watch ended");
+                    tracing::debug!("Watch ended");
                     Ok(())
                 }
-                .map_err(|_: mpsc::error::SendError<_>| tracing::info!("lookup closed"))
+                .map_err(|_: mpsc::error::SendError<_>| tracing::info!("Lookup closed"))
                 .in_current_span(),
             );
             rx
         } else {
-            tracing::info!(?dst, "does not exist");
+            tracing::info!("Does not exist");
             let (mut tx, rx) = mpsc::channel(1);
             let _ = tx
                 .send(Ok(pb::Update {
@@ -160,10 +160,9 @@ impl Destination for DstService {
 
     async fn get_profile(
         &self,
-        req: tonic::Request<GetDestination>,
+        _: tonic::Request<GetDestination>,
     ) -> GrpcResult<tonic::Response<Self::GetProfileStream>> {
-        let GetDestination { path, .. } = req.into_inner();
-        tracing::debug!(?path, "not implemented");
+        tracing::debug!("Not implemented");
         Err(tonic::Status::invalid_argument("not implemented"))
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,4 @@
-use linkerd2_mock_dst::DstSpec;
-use std::error::Error;
+use linkerd2_mock_dst::DstSpec; use std::error::Error;
 use std::fmt;
 use std::net::SocketAddr;
 use structopt::StructOpt;
@@ -18,8 +17,9 @@ struct CliOpts {
     ///
     /// This is parsed as a list of `DESTINATION=ENDPOINTS` pairs, where
     /// `DESTINATION` is a scheme, DNS name, and port, and `ENDPOINTS` is a
-    /// comma-separated list of socket addresses. Each pair is separated by
-    /// semicolons.
+    /// comma-separated list of endpoints. Each pair is separated by
+    /// semicolons. An endpoint consists of a an `IP:PORT` and an optional
+    /// `#h2` suffix, if the endpoint supports meshed protocol upgrading.
     #[structopt(name = "DSTS", env = "LINKERD2_MOCK_DSTS", parse(try_from_str = parse_dsts))]
     dsts: DstSpec,
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,7 +2,6 @@ use linkerd2_mock_dst::DstSpec;
 use std::error::Error;
 use std::fmt;
 use std::net::SocketAddr;
-
 use structopt::StructOpt;
 
 #[derive(Debug, StructOpt)]
@@ -36,8 +35,8 @@ async fn main() -> Result<(), Termination> {
     tracing::subscriber::set_global_default(subscriber)?;
 
     let opts = CliOpts::from_args();
-    tracing::trace!(opts = format_args!("{:#?}", opts));
     let CliOpts { dsts, addr } = opts;
+    tracing::debug!(?dsts);
 
     let (_handle, svc) = dsts.into_svc();
     svc.serve(addr).await?;

--- a/src/spec.rs
+++ b/src/spec.rs
@@ -89,6 +89,7 @@ impl FromStr for Endpoints {
                 let span = tracing::error_span!("parse_addr", ?addr);
                 let _g = span.enter();
 
+                // Addresses may have the suffix `#h2` to indicate they support h2 upgrading.
                 let mut parts = addr.splitn(2, '#');
                 match (parts.next(), parts.next()) {
                     (Some(addr), h2) => match addr.parse() {


### PR DESCRIPTION
The proxy doesn't use the `scheme` field at the moment, so ignore it.
But ports are required on addresses. Modify the controller to support
this, and modify logging for practical diagnostics.