### PR TITLE
Add support for destination overrides

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -17,7 +17,7 @@ struct CliOpts {
     /// A list of destination endpoints to serve.
     ///
     /// This is parsed as a list of `DESTINATION=ENDPOINTS` pairs, where `DESTINATION` is a DNS name
-    /// and port, and `ENDPOINTS` is a comma-separated list of endpoints. Each pair is separatedby
+    /// and port, and `ENDPOINTS` is a comma-separated list of endpoints. Each pair is separated by
     /// semicolons. An endpoint consists of a an`IP:PORT` and an optional `#h2` suffix, if the
     /// endpoint supports meshed protocol upgrading.
     #[structopt(long = "endpoints", env = "LINKERD2_MOCK_DST_ENDPOINTS", parse(try_from_str = parse_endpoints))]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,5 @@
-use linkerd2_mock_dst::DstSpec; use std::error::Error;
+use linkerd2_mock_dst::{DstService, EndpointsSpec, OverridesSpec};
+use std::error::Error;
 use std::fmt;
 use std::net::SocketAddr;
 use structopt::StructOpt;
@@ -13,15 +14,23 @@ struct CliOpts {
     #[structopt(short = "a", long = "addr", default_value = "0.0.0.0:8086")]
     addr: SocketAddr,
 
-    /// A list of mock destinations to serve.
+    /// A list of destination endpoints to serve.
     ///
-    /// This is parsed as a list of `DESTINATION=ENDPOINTS` pairs, where
-    /// `DESTINATION` is a scheme, DNS name, and port, and `ENDPOINTS` is a
-    /// comma-separated list of endpoints. Each pair is separated by
-    /// semicolons. An endpoint consists of a an `IP:PORT` and an optional
-    /// `#h2` suffix, if the endpoint supports meshed protocol upgrading.
-    #[structopt(name = "DSTS", env = "LINKERD2_MOCK_DSTS", parse(try_from_str = parse_dsts))]
-    dsts: DstSpec,
+    /// This is parsed as a list of `DESTINATION=ENDPOINTS` pairs, where `DESTINATION` is a DNS name
+    /// and port, and `ENDPOINTS` is a comma-separated list of endpoints. Each pair is separatedby
+    /// semicolons. An endpoint consists of a an`IP:PORT` and an optional `#h2` suffix, if the
+    /// endpoint supports meshed protocol upgrading.
+    #[structopt(long = "endpoints", env = "LINKERD2_MOCK_DST_ENDPOINTS", parse(try_from_str = parse_endpoints))]
+    endpoints: EndpointsSpec,
+
+    /// A list of destination overrides to serve.
+    ///
+    /// This is parsed as a list of `DESTINATION=OVERRIDES` pairs, where `DESTINATION` is a DNS name
+    /// and port, and `OVERRIDES` is a comma-separated list of overrides. Each pair is separated by
+    /// semicolons. An override consists of a an `NAME:PORT` and an optional `*WEIGHT` suffix.
+    /// `WEIGHT`s are integers. If unspecifified, the default weight of 1000 is used.
+    #[structopt(long = "overrides", env = "LINKERD2_MOCK_DST_OVERRIDES", parse(try_from_str = parse_overrides))]
+    overrides: OverridesSpec,
 }
 
 #[tokio::main]
@@ -35,16 +44,24 @@ async fn main() -> Result<(), Termination> {
     tracing::subscriber::set_global_default(subscriber)?;
 
     let opts = CliOpts::from_args();
-    let CliOpts { dsts, addr } = opts;
-    tracing::debug!(?dsts);
+    let CliOpts {
+        endpoints,
+        overrides,
+        addr,
+    } = opts;
+    tracing::debug!(?endpoints, ?overrides);
 
-    let (_handle, svc) = dsts.into_svc();
+    let (_sender, svc) = DstService::new(endpoints, overrides);
     svc.serve(addr).await?;
     Ok(())
 }
 
-fn parse_dsts(dsts: &str) -> Result<DstSpec, Termination> {
-    dsts.parse().map_err(Into::into)
+fn parse_endpoints(s: &str) -> Result<EndpointsSpec, Termination> {
+    s.parse().map_err(Into::into)
+}
+
+fn parse_overrides(s: &str) -> Result<OverridesSpec, Termination> {
+    s.parse().map_err(Into::into)
 }
 
 struct Termination(Box<dyn Error>);

--- a/src/spec.rs
+++ b/src/spec.rs
@@ -154,7 +154,7 @@ impl FromStr for Overrides {
                 let span = tracing::error_span!("parse_addr", ?addr);
                 let _g = span.enter();
 
-                // Destiantions may have the suffix `*W` to indicate a weight.
+                // Destinations may have the suffix `*W` to indicate a weight.
                 let mut parts = addr.splitn(2, '*');
                 match (parts.next(), parts.next()) {
                     (Some(dst), weight) => match (dst.parse(), weight) {


### PR DESCRIPTION
In order to test destination overrides (aka TrafficSplit), the mock-dst
controller needs limited support for service profiles.

This change adds an `--overrides` flag that supports configuration of a
list of weighted destination overrides. The previous _dsts_
configuration has been moved into the `--endpoints` flag.