### PR TITLE
Add metric labels to endpoint responses

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -49,7 +49,7 @@ async fn main() -> Result<(), Termination> {
         overrides,
         addr,
     } = opts;
-    tracing::debug!(?endpoints, ?overrides);
+    tracing::debug!(?endpoints, ?overrides, ?addr);
 
     let (_sender, svc) = DstService::new(endpoints, overrides);
     svc.serve(addr).await?;


### PR DESCRIPTION
In order to distinguish concrete endpoints in traffic split, we expect
resolutions to include metric labels. This change adds a `concrete`
label for services and `addr` and `h2` labels for individual endpoints.