### PR TITLE
Permit initialization with empty configuration

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -20,7 +20,7 @@ struct CliOpts {
     /// and port, and `ENDPOINTS` is a comma-separated list of endpoints. Each pair is separated by
     /// semicolons. An endpoint consists of a an`IP:PORT` and an optional `#h2` suffix, if the
     /// endpoint supports meshed protocol upgrading.
-    #[structopt(long = "endpoints", env = "LINKERD2_MOCK_DST_ENDPOINTS", parse(try_from_str = parse_endpoints))]
+    #[structopt(long = "endpoints", env = "LINKERD2_MOCK_DST_ENDPOINTS", default_value = "", parse(try_from_str = parse_endpoints))]
     endpoints: EndpointsSpec,
 
     /// A list of destination overrides to serve.
@@ -29,7 +29,7 @@ struct CliOpts {
     /// and port, and `OVERRIDES` is a comma-separated list of overrides. Each pair is separated by
     /// semicolons. An override consists of a an `NAME:PORT` and an optional `*WEIGHT` suffix.
     /// `WEIGHT`s are integers. If unspecifified, the default weight of 1000 is used.
-    #[structopt(long = "overrides", env = "LINKERD2_MOCK_DST_OVERRIDES", parse(try_from_str = parse_overrides))]
+    #[structopt(long = "overrides", env = "LINKERD2_MOCK_DST_OVERRIDES", default_value = "", parse(try_from_str = parse_overrides))]
     overrides: OverridesSpec,
 }
 

--- a/src/spec.rs
+++ b/src/spec.rs
@@ -30,6 +30,10 @@ impl FromStr for EndpointsSpec {
 
     #[tracing::instrument(name = "EndpointsSpec::from_str", level = "error")]
     fn from_str(spec: &str) -> Result<Self, Self::Err> {
+        if spec.is_empty() {
+            return Ok(Self::default());
+        }
+
         #[tracing::instrument(level = "info")]
         fn parse_entry(entry: &str) -> Result<(Dst, Endpoints), TracedError<ParseError>> {
             let mut parts = entry.split('=');
@@ -121,6 +125,10 @@ impl FromStr for OverridesSpec {
 
     #[tracing::instrument(name = "OverridesSpec::from_str", level = "error")]
     fn from_str(spec: &str) -> Result<Self, Self::Err> {
+        if spec.is_empty() {
+            return Ok(Self::default());
+        }
+
         #[tracing::instrument(level = "info")]
         fn parse_entry(entry: &str) -> Result<(Dst, Overrides), TracedError<ParseError>> {
             let mut parts = entry.split('=');


### PR DESCRIPTION
Sometimes it's useful to run the server without any discovery information.

Update the specs to support empty values.