### PR TITLE
Add ability to watch fs for endpoint updates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -47,9 +47,9 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.35"
+version = "0.1.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89cb5d814ab2a47fd66d3266e9efccb53ca4c740b7451043b8ffcf9a6208f3f8"
+checksum = "a265e3abeffdce30b2e26b7a11b222fe37c6067404001b434101457d0385eb92"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -93,9 +93,18 @@ checksum = "08c48aae112d48ed9f069b33538ea9e3e90aa263cfa3d1c24309612b1f7472de"
 
 [[package]]
 name = "bytes"
-version = "0.5.4"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "130aac562c0dd69c56b3b1cc8ffd2e17be31d0b6c25b61c96b76231aa23e39e1"
+checksum = "118cf036fbb97d0816e3c34b2d7a1e8cfc60f68fcf63d550ddbe9bd5f59c213b"
+dependencies = [
+ "loom",
+]
+
+[[package]]
+name = "cc"
+version = "1.0.54"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7bbb73db36c1246e9034e307d0fba23f9a2e251faa47ade70c1bd252220c8311"
 
 [[package]]
 name = "cfg-if"
@@ -259,6 +268,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "generator"
+version = "0.6.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "add72f17bb81521258fcc8a7a3245b1e184e916bfbe34f0ea89558f440df5c68"
+dependencies = [
+ "cc",
+ "libc",
+ "log",
+ "rustc_version",
+ "winapi 0.3.8",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -367,6 +389,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "inotify"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46dd0a94b393c730779ccfd2a872b67b1eb67be3fc33082e733bdb38b5fde4d4"
+dependencies = [
+ "bitflags",
+ "futures-core",
+ "inotify-sys",
+ "libc",
+ "mio",
+ "tokio",
+]
+
+[[package]]
+name = "inotify-sys"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e74a1aa87c59aeff6ef2cc2fa62d41bc43f54952f55652656b18a02fd5e356c0"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "iovec"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -417,7 +462,12 @@ name = "linkerd2-mock-dst"
 version = "0.1.0"
 dependencies = [
  "futures",
+ "inotify",
+ "inotify-sys",
+ "libc",
  "linkerd2-proxy-api",
+ "serde",
+ "serde_json",
  "structopt",
  "tokio",
  "tonic",
@@ -430,7 +480,7 @@ dependencies = [
 [[package]]
 name = "linkerd2-proxy-api"
 version = "0.1.12"
-source = "git+https://github.com/linkerd/linkerd2-proxy-api#433b31ea86b519a0123b5c9a575549238826dcac"
+source = "git+https://github.com/linkerd/linkerd2-proxy-api#c442280b7c1e8c5a83d53abe00287aca69129d7c"
 dependencies = [
  "h2",
  "http",
@@ -447,6 +497,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14b6052be84e6b71ab17edffc2eeabf5c2c3ae1fdb464aae35ac50c67a44e1f7"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "loom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ecc775857611e1df29abba5c41355cdf540e7e9d4acfdf0f355eefee82330b7"
+dependencies = [
+ "cfg-if",
+ "generator",
+ "scoped-tls",
 ]
 
 [[package]]
@@ -803,16 +864,60 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc_version"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "ryu"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
 
 [[package]]
-name = "serde"
-version = "1.0.112"
+name = "scoped-tls"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "736aac72d1eafe8e5962d1d1c3d99b0df526015ba40915cb3c49d042e92ec243"
+checksum = "332ffa32bf586782a3efaeb58f127980944bbc8c4d6913a86107ac2a5ab24b28"
+
+[[package]]
+name = "semver"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
+dependencies = [
+ "semver-parser",
+]
+
+[[package]]
+name = "semver-parser"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
+
+[[package]]
+name = "serde"
+version = "1.0.114"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5317f7588f0a5078ee60ef675ef96735a1442132dc645eb1d12c018620ed8cd3"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.114"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a0be94b04690fbaed37cddffc5c134bf537c8e3329d53e982fe04c374978f8e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "serde_json"
@@ -890,9 +995,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.31"
+version = "1.0.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5304cfdf27365b7585c25d4af91b35016ed21ef88f17ced89c7093b43dba8b6"
+checksum = "e8d5d96e8cbb005d6959f119f773bfaebb5684296108fb32600c00cde305b2cd"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1291,9 +1396,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d53c40489aa69c9aed21ff483f26886ca8403df33bdc2d2f87c60c1617826d2"
+checksum = "04a11b459109e38ff6e1b580bafef4142a11d44889f5d07424cbce2fd2a2a119"
 dependencies = [
  "ansi_term",
  "chrono",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -139,6 +139,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dtoa"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "134951f4028bdadb9b84baf4232681efbf277da25144b9b0ad65df75946c422b"
+
+[[package]]
 name = "either"
 version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -458,6 +464,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9457b06509d27052635f90d6466700c65095fdf75409b3fbdd903e988b886f49"
 
 [[package]]
+name = "linked-hash-map"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8dd5a6d5999d9907cda8ed67bbd137d3af8085216c2ac62de5be860bd41f304a"
+
+[[package]]
 name = "linkerd2-mock-dst"
 version = "0.1.0"
 dependencies = [
@@ -468,6 +480,7 @@ dependencies = [
  "linkerd2-proxy-api",
  "serde",
  "serde_json",
+ "serde_yaml",
  "structopt",
  "tokio",
  "tonic",
@@ -928,6 +941,18 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "serde_yaml"
+version = "0.8.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae3e2dd40a7cdc18ca80db804b7f461a39bb721160a85c9a1fa30134bf3c02a5"
+dependencies = [
+ "dtoa",
+ "linked-hash-map",
+ "serde",
+ "yaml-rust",
 ]
 
 [[package]]
@@ -1517,4 +1542,13 @@ checksum = "d59cefebd0c892fa2dd6de581e937301d8552cb44489cdff035c6187cb63fa5e"
 dependencies = [
  "winapi 0.2.8",
  "winapi-build",
+]
+
+[[package]]
+name = "yaml-rust"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39f0c922f1a334134dc2f7a8b67dc5d25f0735263feec974345ff706bcf20b0d"
+dependencies = [
+ "linked-hash-map",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,5 +18,6 @@ futures = "0.3"
 inotify = "0.8.3"
 serde = { version = "1.0.104", features = ["derive"] }
 serde_json  = "1.0.27"
+serde_yaml = "0.8.13"
 inotify-sys = "0.1.3"
 libc = "0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 publish = false
 
 [dependencies]
-tokio = { version = "0.2", features = ["macros", "rt-threaded", "sync", "blocking"] }
+tokio = { version = "0.2", features = ["macros", "rt-threaded", "sync", "fs"] }
 tonic = "0.2.1"
 linkerd2-proxy-api = { git = "https://github.com/linkerd/linkerd2-proxy-api", features = ["transport"] }
 tracing = "0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 publish = false
 
 [dependencies]
-tokio = { version = "0.2", features = ["macros", "rt-threaded", "sync"] }
+tokio = { version = "0.2", features = ["macros", "rt-threaded", "sync", "blocking"] }
 tonic = "0.2.1"
 linkerd2-proxy-api = { git = "https://github.com/linkerd/linkerd2-proxy-api", features = ["transport"] }
 tracing = "0.1"
@@ -15,3 +15,8 @@ tracing-subscriber = "0.2"
 tracing-futures = "0.2"
 structopt = "0.3"
 futures = "0.3"
+inotify = "0.8.3"
+serde = { version = "1.0.104", features = ["derive"] }
+serde_json  = "1.0.27"
+inotify-sys = "0.1.3"
+ libc = "0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,4 +19,4 @@ inotify = "0.8.3"
 serde = { version = "1.0.104", features = ["derive"] }
 serde_json  = "1.0.27"
 inotify-sys = "0.1.3"
- libc = "0.2"
+libc = "0.2"

--- a/src/fs_watcher.rs
+++ b/src/fs_watcher.rs
@@ -1,0 +1,75 @@
+use crate::DstSender;
+use crate::Endpoints;
+use inotify::{Event, EventMask, Inotify, WatchMask};
+use inotify_sys as ffi;
+use serde_json;
+use std::error::Error;
+use std::ffi::OsString;
+use std::mem;
+use std::string::String;
+use std::{fs, path};
+use tokio::stream::StreamExt;
+
+use crate::Dst;
+use crate::EndpointMeta;
+
+const EVENT_BUF_SZ: usize =
+    mem::size_of::<ffi::inotify_event>() + (libc::FILENAME_MAX as usize) + 1;
+
+#[derive(Debug)]
+pub struct FsWatcher {
+    endpoints_dir: String,
+    dst_sender: DstSender,
+}
+
+impl FsWatcher {
+    pub fn new(endpoints_dir: String, dst_sender: DstSender) -> Self {
+        Self {
+            endpoints_dir,
+            dst_sender,
+        }
+    }
+
+    #[tracing::instrument(skip(self), name = "FsWatcher::handle_event", level = "info")]
+    fn handle_event(
+        &mut self,
+        ev: Event<OsString>,
+    ) -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
+        if let Some(file_name) = ev.name.and_then(|s| s.to_str().map(|s| s.to_string())) {
+            let dst: Dst = file_name.parse()?;
+            if ev.mask == EventMask::DELETE {
+                tracing::info!(?dst, "deleted");
+                self.dst_sender.delete_dst(dst);
+            } else {
+                let path = path::Path::new(&self.endpoints_dir).join(file_name);
+                let contents = fs::read_to_string(path)?;
+                let dsts = serde_json::from_str::<Vec<EndpointMeta>>(&contents)?
+                    .into_iter()
+                    .map(|e| (e.address, e))
+                    .collect();
+                let endpoints = Endpoints(dsts);
+                tracing::info!(?endpoints, "added");
+                self.dst_sender.send_endpoints(dst, endpoints)?
+            }
+        }
+        Ok(())
+    }
+
+    pub async fn watch(&mut self) -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
+        let mut inotify = Inotify::init()?;
+        let mask = WatchMask::MODIFY | WatchMask::DELETE;
+        inotify.add_watch(self.endpoints_dir.clone(), mask)?;
+        let stream = inotify.event_stream(Vec::from(&[0; EVENT_BUF_SZ][..]))?;
+        stream
+            .map(|event| {
+                if let Ok(event) = event {
+                    if let Err(e) = self.handle_event(event) {
+                        tracing::error!(?e, "error handing event");
+                    }
+                }
+                Ok(())
+            })
+            .collect()
+            .await
+    }
+}

--- a/src/fs_watcher.rs
+++ b/src/fs_watcher.rs
@@ -1,16 +1,16 @@
+use crate::Dst;
 use crate::DstSender;
+use crate::EndpointMeta;
 use crate::Endpoints;
 use inotify::{Event, EventMask, Inotify, WatchMask};
 use inotify_sys as ffi;
 use serde_json;
+use serde_yaml;
 use std::error::Error;
 use std::ffi::OsString;
 use std::mem;
 use std::{fs, path::PathBuf};
 use tokio::stream::StreamExt;
-
-use crate::Dst;
-use crate::EndpointMeta;
 
 const EVENT_BUF_SZ: usize =
     mem::size_of::<ffi::inotify_event>() + (libc::FILENAME_MAX as usize) + 1;
@@ -21,6 +21,33 @@ pub struct FsWatcher {
     dst_sender: DstSender,
 }
 
+#[derive(Debug)]
+enum FileType {
+    Yaml,
+    Json,
+}
+
+#[derive(Debug)]
+pub struct FsWatcherError {
+    reason: &'static str,
+}
+
+macro_rules! fs_watcher_error {
+    ($reason:expr) => {{
+        return Err(Box::new(FsWatcherError { reason: $reason }));
+    }};
+}
+
+// === impl ParseError ===
+
+impl std::fmt::Display for FsWatcherError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        std::fmt::Display::fmt(&self.reason, f)
+    }
+}
+
+impl Error for FsWatcherError {}
+
 impl FsWatcher {
     pub fn new(endpoints_dir: PathBuf, dst_sender: DstSender) -> Self {
         Self {
@@ -29,24 +56,55 @@ impl FsWatcher {
         }
     }
 
+    fn parse_dst(
+        file_name: &str,
+    ) -> Result<(Dst, FileType), Box<dyn Error + Send + Sync + 'static>> {
+        let mut parts = file_name.rsplitn(2, ".");
+        match (parts.next(), parts.next()) {
+            (Some(ext), Some(name)) => {
+                let dst: Dst = name.parse()?;
+                let ft = match ext {
+                    "yaml" => FileType::Yaml,
+                    "json" => FileType::Json,
+                    _ => fs_watcher_error!("invalid file ext"),
+                };
+                Ok((dst, ft))
+            }
+            _ => fs_watcher_error!("invalid file ext"),
+        }
+    }
+
+    fn parse_file(
+        &self,
+        file_name: &str,
+        ft: FileType,
+    ) -> Result<Endpoints, Box<dyn Error + Send + Sync + 'static>> {
+        let path = self.endpoints_dir.join(file_name);
+        let contents = fs::read_to_string(path)?;
+        let destinations = match ft {
+            FileType::Json => {
+                serde_json::from_str::<Vec<EndpointMeta>>(&contents).map_err(|e| e.into())
+            }
+            FileType::Yaml => {
+                serde_yaml::from_str::<Vec<EndpointMeta>>(&contents).map_err(|e| e.into())
+            }
+        };
+
+        destinations.map(|dsts| Endpoints(dsts.into_iter().map(|e| (e.address, e)).collect()))
+    }
+
     #[tracing::instrument(skip(self), name = "FsWatcher::handle_event", level = "info")]
     fn handle_event(
         &mut self,
         ev: Event<OsString>,
     ) -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
         if let Some(file_name) = ev.name.and_then(|s| s.to_str().map(|s| s.to_string())) {
-            let dst: Dst = file_name.parse()?;
+            let (dst, ft) = Self::parse_dst(&file_name)?;
             if ev.mask == EventMask::DELETE {
                 tracing::info!(?dst, "deleted");
                 self.dst_sender.delete_dst(dst);
             } else {
-                let path = self.endpoints_dir.join(file_name);
-                let contents = fs::read_to_string(path)?;
-                let dsts = serde_json::from_str::<Vec<EndpointMeta>>(&contents)?
-                    .into_iter()
-                    .map(|e| (e.address, e))
-                    .collect();
-                let endpoints = Endpoints(dsts);
+                let endpoints = self.parse_file(&file_name, ft)?;
                 tracing::info!(?endpoints, "added");
                 self.dst_sender.send_endpoints(dst, endpoints)?
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,7 @@ use linkerd2_mock_dst::{DstService, EndpointsSpec, FsWatcher, OverridesSpec};
 use std::error::Error;
 use std::fmt;
 use std::net::SocketAddr;
+use std::path::PathBuf;
 use structopt::StructOpt;
 
 #[derive(Debug, StructOpt)]
@@ -39,10 +40,10 @@ struct CliOpts {
     /// directory is provided the `endpoints` and `overrides` opts will be ignored and the discovery
     /// state will be derived from the contents of the directory only.
     #[structopt(
-        long = "endpoints_watch_directory",
-        env = "LINKERD2_MOCK_DST_ENDPOINTS_WATCH_DIRECTORY"
+        long = "endpoints_dir",
+                env = "LINKERD2_MOCK_DST_ENDPOINTS_DIR",  conflicts_with_all = &["overrides", "endpoints"],
     )]
-    endpoints_watch_directory: Option<String>,
+    endpoints_dir: Option<PathBuf>,
 }
 
 #[tokio::main]
@@ -60,11 +61,11 @@ async fn main() -> Result<(), Termination> {
         endpoints,
         overrides,
         addr,
-        endpoints_watch_directory,
+        endpoints_dir,
     } = opts;
-    tracing::debug!(?endpoints, ?overrides, ?addr, ?endpoints_watch_directory);
+    tracing::debug!(?endpoints, ?overrides, ?addr, ?endpoints_dir);
 
-    match endpoints_watch_directory {
+    match endpoints_dir {
         Some(endpoints) => {
             let (sender, svc) = DstService::empty();
             let mut fs_watcher = FsWatcher::new(endpoints, sender);

--- a/src/main.rs
+++ b/src/main.rs
@@ -36,7 +36,7 @@ struct CliOpts {
     /// A directory that is dynamically watched for endpoints updates
     ///
     /// The directory contains files with names in the form of {dst.name}:{port}. Each file should
-    /// contain the json representation of a list of `EndpointMeta` objects. Not that if such a
+    /// contain the json or yaml representation of a list of `EndpointMeta` objects. Note that if such a
     /// directory is provided the `endpoints` and `overrides` opts will be ignored and the discovery
     /// state will be derived from the contents of the directory only.
     #[structopt(

--- a/src/main.rs
+++ b/src/main.rs
@@ -32,6 +32,12 @@ struct CliOpts {
     #[structopt(long = "overrides", env = "LINKERD2_MOCK_DST_OVERRIDES", default_value = "", parse(try_from_str = parse_overrides))]
     overrides: OverridesSpec,
 
+    /// A directory that is dynamically watched for endpoints updates
+    ///
+    /// The directory contains files with names in the form of {dst.name}:{port}. Each file should
+    /// contain the json representation of a list of `EndpointMeta` objects. Not that if such a
+    /// directory is provided the `endpoints` and `overrides` opts will be ignored and the discovery
+    /// state will be derived from the contents of the directory only.
     #[structopt(
         long = "endpoints_watch_directory",
         env = "LINKERD2_MOCK_DST_ENDPOINTS_WATCH_DIRECTORY"

--- a/src/spec.rs
+++ b/src/spec.rs
@@ -1,5 +1,6 @@
 use super::{Dst, EndpointMeta, Endpoints, Overrides};
-use std::{collections::HashMap, error::Error, str::FromStr};
+use std::collections::{BTreeMap, HashMap};
+use std::{default::Default, error::Error, str::FromStr};
 use tracing_error::{prelude::*, TracedError};
 
 #[derive(Debug, Default)]
@@ -105,7 +106,12 @@ impl FromStr for Endpoints {
                         Ok(addr) => Ok((
                             addr,
                             EndpointMeta {
+                                address: addr,
                                 h2: h2.map(|proto| proto == "h2").unwrap_or(false),
+                                weight: 10_000,
+                                metric_labels: BTreeMap::default(),
+                                tls_identity: None,
+                                authority_override: None,
                             },
                         )),
                         Err(_) => parse_error!("invalid socket address"),


### PR DESCRIPTION
This change adds the option to specify an endpoints directory to be used for deriving the discovery state. As pointed out in the comments there is the `endpoints_watch_directory` which when set causes the mock to read endpoints state from the files system instead of using a static config. The directory should contain files with names in the form of {name}:{port} with content such as: 

```json
[
  {
    "address": "127.0.0.1:8888",
    "h2": true,
    "weight": 5,
    "tls_identity": "some_id2",
    "metric_labels": {
      "label1": "value1"
    }
  },
  {
    "address": "127.0.0.5:8888",
    "h2": false,
    "weight": 15,
    "tls_identity": "some_id1",
    "metric_labels": {
      "label2": "value2"
    }
  }
]
```


You can test it with the following yaml: 

```yaml
apiVersion: v1
kind: Pod
metadata:
  name: mock-dst-test
spec:
  containers:
    - name: test
      image: mock-dst-test:thm5
      env:
      - name: "RUST_LOG"
        value: "info"
      - name: "LINKERD2_MOCK_DST_ENDPOINTS_WATCH_DIRECTORY"
        value: "/tmp/endpoints"
      volumeMounts:
      - mountPath: /tmp/endpoints
        name: endpoints
      ports:
      - containerPort: 8086
  volumes:
  - name: endpoints
    emptyDir: {}
```