### PR TITLE
Add mock identity service

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -80,10 +80,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b41b7ea54a0c9d92199de89e20e58d49f02f8e699814ef3fdf266f6f748d15c7"
 
 [[package]]
+name = "base64"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3441f0f7b02788e948e47f457ca01f1d7e6d92c693bc132c22b087d3141c03ff"
+
+[[package]]
 name = "bitflags"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
+
+[[package]]
+name = "bumpalo"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e8c087f005730276d1096a652e92a8bacee2e2472bcc9715a74d2bec38b5820"
 
 [[package]]
 name = "byteorder"
@@ -442,6 +454,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc6f3ad7b9d11a0c00842ff8de1b60ee58661048eb8049ed33c73594f359d7e6"
 
 [[package]]
+name = "js-sys"
+version = "0.3.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85a7e2c92a4804dd459b86c339278d0fe87cf93757fae222c3fa3ae75458bc73"
+dependencies = [
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "kernel32-sys"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -478,6 +499,7 @@ dependencies = [
  "inotify-sys",
  "libc",
  "linkerd2-proxy-api",
+ "rustls",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -877,12 +899,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "ring"
+version = "0.16.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "952cd6b98c85bbc30efa1ba5783b8abf12fec8b3287ffa52605b9432313e34e4"
+dependencies = [
+ "cc",
+ "libc",
+ "once_cell",
+ "spin",
+ "untrusted",
+ "web-sys",
+ "winapi 0.3.8",
+]
+
+[[package]]
 name = "rustc_version"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
 dependencies = [
  "semver",
+]
+
+[[package]]
+name = "rustls"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cac94b333ee2aac3284c5b8a1b7fb4dd11cba88c244e3fe33cdbd047af0eb693"
+dependencies = [
+ "base64 0.12.3",
+ "log",
+ "ring",
+ "sct",
+ "webpki",
 ]
 
 [[package]]
@@ -896,6 +946,16 @@ name = "scoped-tls"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "332ffa32bf586782a3efaeb58f127980944bbc8c4d6913a86107ac2a5ab24b28"
+
+[[package]]
+name = "sct"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3042af939fca8c3453b7af0f1c66e533a15a86169e39de2657310ade8f98d3c"
+dependencies = [
+ "ring",
+ "untrusted",
+]
 
 [[package]]
 name = "semver"
@@ -987,6 +1047,12 @@ dependencies = [
  "redox_syscall",
  "winapi 0.3.8",
 ]
+
+[[package]]
+name = "spin"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "strsim"
@@ -1134,7 +1200,7 @@ checksum = "4afef9ce97ea39593992cf3fa00ff33b1ad5eb07665b31355df63a690e38c736"
 dependencies = [
  "async-stream",
  "async-trait",
- "base64",
+ "base64 0.11.0",
  "bytes",
  "futures-core",
  "futures-util",
@@ -1464,6 +1530,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c"
 
 [[package]]
+name = "untrusted"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
+
+[[package]]
 name = "vec_map"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1490,6 +1562,80 @@ name = "wasi"
 version = "0.9.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.67"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0563a9a4b071746dd5aedbc3a28c6fe9be4586fb3fbadb67c400d4f53c6b16c"
+dependencies = [
+ "cfg-if",
+ "wasm-bindgen-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-backend"
+version = "0.2.67"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc71e4c5efa60fb9e74160e89b93353bc24059999c0ae0fb03affc39770310b0"
+dependencies = [
+ "bumpalo",
+ "lazy_static",
+ "log",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.67"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97c57cefa5fa80e2ba15641578b44d36e7a64279bc5ed43c6dbaf329457a2ed2"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.67"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841a6d1c35c6f596ccea1f82504a192a60378f64b3bb0261904ad8f2f5657556"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-backend",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.67"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93b162580e34310e5931c4b792560108b10fd14d64915d7fff8ff00180e70092"
+
+[[package]]
+name = "web-sys"
+version = "0.3.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dda38f4e5ca63eda02c059d243aa25b5f35ab98451e518c51612cd0f1bd19a47"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab146130f5f790d45f82aeeb09e55a256573373ec64409fc19a6fb82fb1032ae"
+dependencies = [
+ "ring",
+ "untrusted",
+]
 
 [[package]]
 name = "which"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,23 +1,24 @@
 [package]
-name = "linkerd2-mock-dst"
-version = "0.1.0"
 authors = ["Linkerd Developers <cncf-linkerd-dev@lists.cncf.io>"]
 edition = "2018"
+name = "linkerd2-mock-dst"
 publish = false
+version = "0.1.0"
 
 [dependencies]
-tokio = { version = "0.2", features = ["macros", "rt-threaded", "sync", "fs"] }
-tonic = "0.2.1"
-linkerd2-proxy-api = { git = "https://github.com/linkerd/linkerd2-proxy-api", features = ["transport"] }
-tracing = "0.1"
-tracing-error = "0.1"
-tracing-subscriber = "0.2"
-tracing-futures = "0.2"
-structopt = "0.3"
 futures = "0.3"
 inotify = "0.8.3"
-serde = { version = "1.0.104", features = ["derive"] }
-serde_json  = "1.0.27"
-serde_yaml = "0.8.13"
 inotify-sys = "0.1.3"
 libc = "0.2"
+linkerd2-proxy-api = {git = "https://github.com/linkerd/linkerd2-proxy-api", features = ["transport"]}
+rustls = "0.18"
+serde = {version = "1.0.104", features = ["derive"]}
+serde_json = "1.0.27"
+serde_yaml = "0.8.13"
+structopt = "0.3"
+tokio = {version = "0.2", features = ["macros", "rt-threaded", "sync", "fs"]}
+tonic = "0.2.1"
+tracing = "0.1"
+tracing-error = "0.1"
+tracing-futures = "0.2"
+tracing-subscriber = "0.2"

--- a/README.md
+++ b/README.md
@@ -47,8 +47,24 @@ ARGS:
 
 ## Examples
 
+Mock destinations for the `foo.ns.svc.cluster.local` service:
+
 ```console
 :; RUST_LOG=linkerd2_mock_dst=info \
    LINKERD2_MOCK_DSTS='http://foo.ns.svc.cluster.local:8080=127.0.0.1:1234,127.0.0.1:1235;http://bar.ns.svc.cluster.local:8081=127.0.0.1:4321' \
+   cargo run
+```
+
+Mock identity for the `foo-ns1-ca1` identity name:
+
+```console
+:; ls /path/to/identities
+foo-ns1-ca1/
+
+:; ls /path/to/identities/foo-ns1-ca1/
+crt.pem csr.der key.p8
+
+:; RUST_LOG=linkerd2_mock_dst=info \
+   LINKERD2_MOCK_DST_IDENTITIES_DIR='/path/to/identities/' \
    cargo run
 ```

--- a/src/destination.rs
+++ b/src/destination.rs
@@ -1,0 +1,382 @@
+use crate::{EndpointsSpec, Error, OverridesSpec};
+use futures::prelude::*;
+use linkerd2_proxy_api::destination::{self as pb, destination_server::Destination};
+use serde::{Deserialize, Serialize};
+use std::{
+    collections::{BTreeMap, HashMap},
+    default::Default,
+    fmt,
+    hash::Hash,
+    net::SocketAddr,
+    sync::{Arc, Weak},
+};
+use tokio::sync::{mpsc, watch, RwLock};
+use tracing_futures::Instrument;
+
+#[derive(Clone, Debug)]
+pub struct DstService {
+    inner: Arc<Inner>,
+}
+
+#[derive(Debug)]
+pub struct DstSender {
+    endpoints: HashMap<Dst, watch::Sender<Endpoints>>,
+    overrides: HashMap<Dst, watch::Sender<Overrides>>,
+    inner: Weak<Inner>,
+}
+
+impl DstSender {
+    #[tracing::instrument(skip(self), name = "DstSender::send_endpoints", level = "info")]
+    pub async fn send_endpoints(&mut self, dst: Dst, endpoints: Endpoints) -> Result<(), Error> {
+        if let Some(sender) = self.endpoints.get(&dst) {
+            tracing::info!("Dst present");
+            sender.broadcast(endpoints)?;
+        } else {
+            tracing::info!("Dst non present");
+            if let Some(inner) = self.inner.upgrade() {
+                let (tx, rx) = watch::channel(endpoints);
+                self.endpoints.insert(dst.clone(), tx);
+                inner.endpoints.write().await.insert(dst, rx);
+            }
+        }
+        Ok(())
+    }
+
+    #[tracing::instrument(skip(self), name = "DstSender::delete_dst", level = "info")]
+    pub async fn delete_dst(&mut self, dst: Dst) {
+        if let Some(sender) = self.endpoints.remove(&dst) {
+            tracing::info!("dropping sender");
+            drop(sender);
+            if let Some(inner) = self.inner.upgrade() {
+                inner.endpoints.write().await.remove(&dst);
+            }
+        } else {
+            tracing::info!("Dst not found");
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct Inner {
+    endpoints: RwLock<HashMap<Dst, watch::Receiver<Endpoints>>>,
+    overrides: RwLock<HashMap<Dst, watch::Receiver<Overrides>>>,
+}
+
+#[derive(Debug, PartialEq, Eq, Default, Clone)]
+pub struct Endpoints(pub HashMap<SocketAddr, EndpointMeta>);
+
+#[derive(Debug, Hash, PartialEq, Eq, Clone, Serialize, Deserialize)]
+pub struct EndpointMeta {
+    pub address: SocketAddr,
+    h2: bool,
+    weight: u32,
+    #[serde(default)]
+    metric_labels: BTreeMap<String, String>,
+    tls_identity: Option<String>,
+    authority_override: Option<String>,
+}
+
+#[derive(Debug, PartialEq, Eq, Default, Clone)]
+pub struct Overrides(HashMap<Dst, u32>);
+
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub struct Dst {
+    name: String,
+    port: u16,
+}
+
+type GrpcResult<T> = Result<T, tonic::Status>;
+
+// === impl DstService ===
+
+impl DstService {
+    pub fn empty() -> (DstSender, DstService) {
+        DstService::new(
+            EndpointsSpec {
+                dsts: HashMap::new(),
+            },
+            OverridesSpec {
+                dsts: HashMap::new(),
+            },
+        )
+    }
+
+    pub fn new(endpoints: EndpointsSpec, overrides: OverridesSpec) -> (DstSender, DstService) {
+        let mut endpoints_txs = HashMap::new();
+        let mut endpoints_rxs = HashMap::new();
+        for (dst, eps) in endpoints.dsts.into_iter() {
+            let (tx, rx) = watch::channel(eps.clone());
+            endpoints_txs.insert(dst.clone(), tx);
+            endpoints_rxs.insert(dst.clone(), rx);
+            tracing::info!(?dst, ?eps, "added");
+        }
+
+        let mut overrides_txs = HashMap::new();
+        let mut overrides_rxs = HashMap::new();
+        for (dst, eps) in overrides.dsts.into_iter() {
+            let (tx, rx) = watch::channel(eps.clone());
+            overrides_txs.insert(dst.clone(), tx);
+            overrides_rxs.insert(dst.clone(), rx);
+            tracing::info!(?dst, ?eps, "added");
+        }
+
+        let inner = Arc::new(Inner {
+            endpoints: RwLock::new(endpoints_rxs),
+            overrides: RwLock::new(overrides_rxs),
+        });
+        let sender = DstSender {
+            endpoints: endpoints_txs,
+            overrides: overrides_txs,
+            inner: Arc::downgrade(&inner),
+        };
+        (sender, Self { inner })
+    }
+
+    #[tracing::instrument(skip(self), level = "info")]
+    async fn stream_endpoints(&self, dst: &Dst) -> mpsc::Receiver<GrpcResult<pb::Update>> {
+        let mut endpoints_rx = match self.inner.endpoints.read().await.get(dst) {
+            Some(rx) => rx.clone(),
+            None => {
+                tracing::info!("Does not exist");
+                let (mut tx, rx) = mpsc::channel(1);
+                let _ = tx
+                    .send(Err(tonic::Status::invalid_argument("not configured")))
+                    .await;
+                return rx;
+            }
+        };
+
+        let concrete_name = dst.to_string();
+
+        tracing::info!("Serving endpoints");
+        let (mut tx, rx) = mpsc::channel(8);
+        tokio::spawn(
+            async move {
+                let mut prev = HashMap::new();
+
+                while let Some(Endpoints(curr)) = endpoints_rx.recv().await {
+                    if curr.is_empty() {
+                        tx.send(Ok(pb::Update {
+                            update: Some(pb::update::Update::NoEndpoints(pb::NoEndpoints {
+                                exists: true,
+                            })),
+                        }))
+                        .await?
+                    } else {
+                        let added = curr
+                            .values()
+                            .filter(|meta| meta.is_add(&prev))
+                            .map(EndpointMeta::to_weighted_addr)
+                            .collect::<Vec<_>>();
+                        if !added.is_empty() {
+                            tracing::debug!(?added);
+
+                            let mut metric_labels = HashMap::default();
+                            metric_labels.insert("concrete".to_string(), concrete_name.clone());
+
+                            tx.send(Ok(pb::Update {
+                                update: Some(pb::update::Update::Add(pb::WeightedAddrSet {
+                                    addrs: added,
+                                    metric_labels,
+                                })),
+                            }))
+                            .await?;
+                        }
+
+                        let removed = prev
+                            .keys()
+                            .filter(|addr| !curr.contains_key(addr))
+                            .map(Into::into)
+                            .collect::<Vec<_>>();
+                        if !removed.is_empty() {
+                            tracing::debug!(?removed);
+                            tx.send(Ok(pb::Update {
+                                update: Some(pb::update::Update::Remove(pb::AddrSet {
+                                    addrs: removed,
+                                })),
+                            }))
+                            .await?;
+                        }
+                    }
+
+                    prev = curr;
+                }
+                tracing::debug!("Watch ended");
+                tx.send(Ok(pb::Update {
+                    update: Some(pb::update::Update::NoEndpoints(pb::NoEndpoints {
+                        exists: false,
+                    })),
+                }))
+                .await?;
+                Ok(())
+            }
+            .map_err(|_: mpsc::error::SendError<_>| tracing::info!("Lookup closed"))
+            .in_current_span(),
+        );
+
+        rx
+    }
+
+    #[tracing::instrument(skip(self), level = "info")]
+    async fn stream_overrides(
+        &self,
+        dst: &Dst,
+    ) -> mpsc::Receiver<GrpcResult<pb::DestinationProfile>> {
+        let mut overrides_rx = match self.inner.overrides.read().await.get(dst) {
+            Some(rx) => rx.clone(),
+            None => {
+                tracing::info!("Does not exist");
+                let (mut tx, rx) = mpsc::channel(1);
+                let _ = tx
+                    .send(Err(tonic::Status::invalid_argument("not configured")))
+                    .await;
+                return rx;
+            }
+        };
+
+        tracing::info!("Serving endpoints");
+        let (mut tx, rx) = mpsc::channel(8);
+        tokio::spawn(
+            async move {
+                while let Some(Overrides(overrides)) = overrides_rx.recv().await {
+                    tracing::debug!(?overrides);
+
+                    let dst_overrides = overrides
+                        .iter()
+                        .map(|(dst, weight)| pb::WeightedDst {
+                            authority: dst.to_string(),
+                            weight: *weight,
+                        })
+                        .collect::<Vec<_>>();
+
+                    tx.send(Ok(pb::DestinationProfile {
+                        dst_overrides,
+                        ..Default::default()
+                    }))
+                    .await?;
+                }
+                tracing::debug!("Watch ended");
+                Ok(())
+            }
+            .map_err(|_: mpsc::error::SendError<_>| tracing::info!("Lookup closed"))
+            .in_current_span(),
+        );
+
+        rx
+    }
+}
+
+#[tonic::async_trait]
+impl Destination for DstService {
+    type GetStream = mpsc::Receiver<GrpcResult<pb::Update>>;
+    type GetProfileStream = mpsc::Receiver<GrpcResult<pb::DestinationProfile>>;
+
+    async fn get(
+        &self,
+        req: tonic::Request<pb::GetDestination>,
+    ) -> GrpcResult<tonic::Response<Self::GetStream>> {
+        let pb::GetDestination { path, .. } = req.into_inner();
+        let dst = path
+            .parse()
+            .map_err(|_| tonic::Status::invalid_argument("invalid dst"))?;
+        let stream = self.stream_endpoints(&dst).await;
+        Ok(tonic::Response::new(stream))
+    }
+
+    async fn get_profile(
+        &self,
+        req: tonic::Request<pb::GetDestination>,
+    ) -> GrpcResult<tonic::Response<Self::GetProfileStream>> {
+        let pb::GetDestination { path, .. } = req.into_inner();
+        let dst = path
+            .parse()
+            .map_err(|_| tonic::Status::invalid_argument("invalid dst"))?;
+        let stream = self.stream_overrides(&dst).await;
+        Ok(tonic::Response::new(stream))
+    }
+}
+
+// === impl Dst ===
+
+impl Dst {
+    pub fn new(name: String, port: u16) -> Dst {
+        Dst { name, port }
+    }
+}
+
+impl fmt::Display for Dst {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}:{}", self.name, self.port)
+    }
+}
+
+// === impl EndpointMeta ===
+
+impl EndpointMeta {
+    pub fn new(
+        address: SocketAddr,
+        h2: bool,
+        weight: u32,
+        metric_labels: BTreeMap<String, String>,
+        tls_identity: Option<String>,
+        authority_override: Option<String>,
+    ) -> EndpointMeta {
+        EndpointMeta {
+            address,
+            h2,
+            weight,
+            metric_labels,
+            tls_identity,
+            authority_override,
+        }
+    }
+
+    fn to_weighted_addr(&self) -> pb::WeightedAddr {
+        let protocol_hint = if self.h2 {
+            Some(pb::ProtocolHint {
+                protocol: Some(pb::protocol_hint::Protocol::H2(
+                    pb::protocol_hint::H2::default(),
+                )),
+            })
+        } else {
+            None
+        };
+
+        let mut metric_labels = HashMap::default();
+        metric_labels.insert("addr".to_string(), self.address.to_string());
+        metric_labels.insert("h2".to_string(), self.h2.to_string());
+        metric_labels.extend(self.metric_labels.clone());
+
+        let ref addr = self.address;
+        pb::WeightedAddr {
+            addr: Some(addr.into()),
+            weight: self.weight,
+            protocol_hint,
+            metric_labels,
+            tls_identity: self.tls_identity.clone().map(|name| pb::TlsIdentity {
+                strategy: Some(pb::tls_identity::Strategy::DnsLikeIdentity(
+                    pb::tls_identity::DnsLikeIdentity { name },
+                )),
+            }),
+            authority_override: self
+                .authority_override
+                .clone()
+                .map(|authority_override| pb::AuthorityOverride { authority_override }),
+        }
+    }
+
+    fn is_add(&self, prev: &HashMap<SocketAddr, EndpointMeta>) -> bool {
+        match prev.get(&self.address) {
+            Some(prev_ep) => prev_ep != self,
+            None => true,
+        }
+    }
+}
+
+// === impl Overrides ===
+
+impl Overrides {
+    pub fn new(dsts: HashMap<Dst, u32>) -> Overrides {
+        Overrides(dsts)
+    }
+}

--- a/src/identity.rs
+++ b/src/identity.rs
@@ -1,0 +1,113 @@
+use linkerd2_proxy_api::identity::{
+    self as pb,
+    identity_server::{Identity, IdentityServer},
+};
+use std::{
+    collections::HashMap,
+    fs::File,
+    io::{self, BufReader, ErrorKind},
+    net::SocketAddr,
+    path::{Path, PathBuf},
+    time::{Duration, SystemTime},
+};
+use tracing_futures::Instrument;
+
+pub type Error = Box<dyn std::error::Error + Send + Sync + 'static>;
+
+pub struct IdentityService {
+    identities: HashMap<String, Certificates>,
+}
+
+struct Certificates {
+    leaf: Vec<u8>,
+    intermediates: Vec<Vec<u8>>,
+}
+
+impl IdentityService {
+    pub fn new(mut path: PathBuf) -> Result<IdentityService, io::Error> {
+        let mut identities = HashMap::new();
+
+        for entry in path.read_dir().expect("read_dir call failed") {
+            if let Ok(entry) = entry {
+                if let Ok(file_type) = entry.file_type() {
+                    if file_type.is_dir() {
+                        path.push(entry.file_name());
+                        path.push("crt.pem");
+                        let certs = Certificates::load(&path)
+                            .expect("failed to load certificates from crt.pem");
+                        let local_name = entry.file_name().into_string().unwrap();
+                        tracing::info!(?local_name, "added");
+                        identities.insert(local_name, certs);
+                    }
+                }
+            }
+        }
+
+        Ok(IdentityService { identities })
+    }
+
+    pub fn empty() -> IdentityService {
+        let identities = HashMap::new();
+        IdentityService { identities }
+    }
+
+    pub async fn serve(self, addr: impl Into<SocketAddr>) -> Result<(), Error> {
+        let addr = addr.into();
+        let span = tracing::info_span!("IdentityService::serve", listen.addr = %addr);
+        tracing::info!(parent: &span, "Starting identity server...");
+
+        tonic::transport::Server::builder()
+            .trace_fn(|headers| tracing::debug_span!("request", ?headers))
+            .add_service(IdentityServer::new(self))
+            .serve(addr)
+            .instrument(span)
+            .await?;
+
+        Ok(())
+    }
+}
+
+impl Certificates {
+    fn load<P>(path: P) -> Result<Certificates, io::Error>
+    where
+        P: AsRef<Path>,
+    {
+        let file = File::open(path)?;
+        let mut reader = BufReader::new(file);
+        let certs = rustls::internal::pemfile::certs(&mut reader)
+            .map_err(|_| io::Error::new(ErrorKind::Other, "rustls error reading certs"))?;
+        let leaf = certs
+            .get(0)
+            .ok_or_else(|| io::Error::new(ErrorKind::Other, "no certs in pemfile"))?
+            .as_ref()
+            .into();
+        let intermediates = certs[1..].iter().map(|i| i.as_ref().into()).collect();
+        Ok(Certificates {
+            leaf,
+            intermediates,
+        })
+    }
+}
+
+#[tonic::async_trait]
+impl Identity for IdentityService {
+    async fn certify(
+        &self,
+        request: tonic::Request<pb::CertifyRequest>,
+    ) -> Result<tonic::Response<pb::CertifyResponse>, tonic::Status> {
+        let pb::CertifyRequest { identity, .. } = request.into_inner();
+        if let Some(certs) = self.identities.get(&identity) {
+            let not_after = SystemTime::now() + Duration::from_secs(666);
+            let response = pb::CertifyResponse {
+                leaf_certificate: certs.leaf.clone(),
+                intermediate_certificates: certs.intermediates.clone(),
+                valid_until: Some(not_after.into()),
+            };
+            return Ok(tonic::Response::new(response));
+        }
+        Err(tonic::Status::not_found(format!(
+            "'{}' identity does not exist",
+            identity
+        )))
+    }
+}

--- a/src/identity.rs
+++ b/src/identity.rs
@@ -68,6 +68,7 @@ impl IdentityService {
 }
 
 impl Certificates {
+    // Taken from: https://github.com/linkerd/linkerd2-proxy/blob/23995e7fb6eae5ede81048bdf9e4f68f7e81c7a9/linkerd/app/integration/src/identity.rs#L44-L64
     fn load<P>(path: P) -> Result<Certificates, io::Error>
     where
         P: AsRef<Path>,
@@ -97,6 +98,9 @@ impl Identity for IdentityService {
     ) -> Result<tonic::Response<pb::CertifyResponse>, tonic::Status> {
         let pb::CertifyRequest { identity, .. } = request.into_inner();
         if let Some(certs) = self.identities.get(&identity) {
+            // Ideally we'd load the `not_after` value from the `crt.pem`, but
+            // that does not seem to be an option with rustls. Therefore,
+            // create a fake expiration.
             let not_after = SystemTime::now() + Duration::from_secs(666);
             let response = pb::CertifyResponse {
                 leaf_certificate: certs.leaf.clone(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -117,17 +117,19 @@ impl DstService {
         let mut endpoints_txs = HashMap::new();
         let mut endpoints_rxs = HashMap::new();
         for (dst, eps) in endpoints.dsts.into_iter() {
-            let (tx, rx) = watch::channel(eps);
+            let (tx, rx) = watch::channel(eps.clone());
             endpoints_txs.insert(dst.clone(), tx);
-            endpoints_rxs.insert(dst, rx);
+            endpoints_rxs.insert(dst.clone(), rx);
+            tracing::info!(?dst, ?eps, "added");
         }
 
         let mut overrides_txs = HashMap::new();
         let mut overrides_rxs = HashMap::new();
         for (dst, eps) in overrides.dsts.into_iter() {
-            let (tx, rx) = watch::channel(eps);
+            let (tx, rx) = watch::channel(eps.clone());
             overrides_txs.insert(dst.clone(), tx);
-            overrides_rxs.insert(dst, rx);
+            overrides_rxs.insert(dst.clone(), rx);
+            tracing::info!(?dst, ?eps, "added");
         }
 
         let inner = Arc::new(Inner {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,378 +1,47 @@
-use futures::prelude::*;
-use linkerd2_proxy_api::destination::{
-    self as pb,
-    destination_server::{Destination, DestinationServer},
-};
-use serde::{Deserialize, Serialize};
-use std::{
-    collections::{BTreeMap, HashMap},
-    default::Default,
-    fmt,
-    hash::Hash,
-    net::SocketAddr,
-    sync::{Arc, Weak},
-};
-use tokio::sync::{mpsc, watch, RwLock};
-use tracing_futures::Instrument;
-
-pub use self::fs_watcher::FsWatcher;
-pub use self::identity::IdentityService;
-pub use self::spec::{EndpointsSpec, OverridesSpec, ParseError};
-
+mod destination;
 mod fs_watcher;
 mod identity;
 mod spec;
 
+pub use self::destination::{Dst, DstSender, DstService, EndpointMeta, Endpoints, Overrides};
+pub use self::fs_watcher::FsWatcher;
+pub use self::identity::IdentityService;
+pub use self::spec::{EndpointsSpec, OverridesSpec};
+
+use linkerd2_proxy_api::{
+    destination::destination_server::DestinationServer, identity::identity_server::IdentityServer,
+};
+use std::net::SocketAddr;
+use tracing_futures::Instrument;
+
 pub type Error = Box<dyn std::error::Error + Send + Sync + 'static>;
 
-#[derive(Clone, Debug)]
-pub struct DstService {
-    inner: Arc<Inner>,
+pub struct Controller {
+    dst_svc: DstService,
+    identity_svc: IdentityService,
 }
 
-#[derive(Debug)]
-pub struct DstSender {
-    endpoints: HashMap<Dst, watch::Sender<Endpoints>>,
-    overrides: HashMap<Dst, watch::Sender<Overrides>>,
-    inner: Weak<Inner>,
-}
-
-impl DstSender {
-    #[tracing::instrument(skip(self), name = "DstSender::send_endpoints", level = "info")]
-    pub async fn send_endpoints(&mut self, dst: Dst, endpoints: Endpoints) -> Result<(), Error> {
-        if let Some(sender) = self.endpoints.get(&dst) {
-            tracing::info!("Dst present");
-            sender.broadcast(endpoints)?;
-        } else {
-            tracing::info!("Dst non present");
-            if let Some(inner) = self.inner.upgrade() {
-                let (tx, rx) = watch::channel(endpoints);
-                self.endpoints.insert(dst.clone(), tx);
-                inner.endpoints.write().await.insert(dst, rx);
-            }
-        }
-        Ok(())
-    }
-
-    #[tracing::instrument(skip(self), name = "DstSender::delete_dst", level = "info")]
-    pub async fn delete_dst(&mut self, dst: Dst) {
-        if let Some(sender) = self.endpoints.remove(&dst) {
-            tracing::info!("dropping sender");
-            drop(sender);
-            if let Some(inner) = self.inner.upgrade() {
-                inner.endpoints.write().await.remove(&dst);
-            }
-        } else {
-            tracing::info!("Dst not found");
+impl Controller {
+    pub fn new(dst_svc: DstService, identity_svc: IdentityService) -> Controller {
+        Controller {
+            dst_svc,
+            identity_svc,
         }
     }
-}
 
-#[derive(Debug)]
-pub struct Inner {
-    endpoints: RwLock<HashMap<Dst, watch::Receiver<Endpoints>>>,
-    overrides: RwLock<HashMap<Dst, watch::Receiver<Overrides>>>,
-}
-
-#[derive(Debug, PartialEq, Eq, Default, Clone)]
-pub struct Endpoints(HashMap<SocketAddr, EndpointMeta>);
-
-#[derive(Debug, Hash, PartialEq, Eq, Clone, Serialize, Deserialize)]
-pub struct EndpointMeta {
-    address: SocketAddr,
-    h2: bool,
-    weight: u32,
-    #[serde(default)]
-    metric_labels: BTreeMap<String, String>,
-    tls_identity: Option<String>,
-    authority_override: Option<String>,
-}
-
-#[derive(Debug, PartialEq, Eq, Default, Clone)]
-struct Overrides(HashMap<Dst, u32>);
-
-#[derive(Clone, Debug, PartialEq, Eq, Hash)]
-pub struct Dst {
-    name: String,
-    port: u16,
-}
-
-type GrpcResult<T> = Result<T, tonic::Status>;
-
-// === impl DstService ===
-
-impl DstService {
-    pub fn empty() -> (DstSender, DstService) {
-        DstService::new(
-            EndpointsSpec {
-                dsts: HashMap::new(),
-            },
-            OverridesSpec {
-                dsts: HashMap::new(),
-            },
-        )
-    }
-
-    pub fn new(endpoints: EndpointsSpec, overrides: OverridesSpec) -> (DstSender, DstService) {
-        let mut endpoints_txs = HashMap::new();
-        let mut endpoints_rxs = HashMap::new();
-        for (dst, eps) in endpoints.dsts.into_iter() {
-            let (tx, rx) = watch::channel(eps.clone());
-            endpoints_txs.insert(dst.clone(), tx);
-            endpoints_rxs.insert(dst.clone(), rx);
-            tracing::info!(?dst, ?eps, "added");
-        }
-
-        let mut overrides_txs = HashMap::new();
-        let mut overrides_rxs = HashMap::new();
-        for (dst, eps) in overrides.dsts.into_iter() {
-            let (tx, rx) = watch::channel(eps.clone());
-            overrides_txs.insert(dst.clone(), tx);
-            overrides_rxs.insert(dst.clone(), rx);
-            tracing::info!(?dst, ?eps, "added");
-        }
-
-        let inner = Arc::new(Inner {
-            endpoints: RwLock::new(endpoints_rxs),
-            overrides: RwLock::new(overrides_rxs),
-        });
-        let sender = DstSender {
-            endpoints: endpoints_txs,
-            overrides: overrides_txs,
-            inner: Arc::downgrade(&inner),
-        };
-        (sender, Self { inner })
-    }
-
-    /// Serves the mock Destination service on the specified socket address.
     pub async fn serve(self, addr: impl Into<SocketAddr>) -> Result<(), Error> {
         let addr = addr.into();
-        let span = tracing::info_span!("DstService::serve", listen.addr = %addr);
-        tracing::info!(parent: &span, "Starting destination server...");
+        let span = tracing::info_span!("Controller::serve", listen.addr = %addr);
+        tracing::info!(parent: &span, "Starting controller server...");
 
         tonic::transport::Server::builder()
             .trace_fn(|headers| tracing::debug_span!("request", ?headers))
-            .add_service(DestinationServer::new(self))
+            .add_service(DestinationServer::new(self.dst_svc))
+            .add_service(IdentityServer::new(self.identity_svc))
             .serve(addr)
             .instrument(span)
             .await?;
 
         Ok(())
-    }
-
-    #[tracing::instrument(skip(self), level = "info")]
-    async fn stream_endpoints(&self, dst: &Dst) -> mpsc::Receiver<GrpcResult<pb::Update>> {
-        let mut endpoints_rx = match self.inner.endpoints.read().await.get(dst) {
-            Some(rx) => rx.clone(),
-            None => {
-                tracing::info!("Does not exist");
-                let (mut tx, rx) = mpsc::channel(1);
-                let _ = tx
-                    .send(Err(tonic::Status::invalid_argument("not configured")))
-                    .await;
-                return rx;
-            }
-        };
-
-        let concrete_name = dst.to_string();
-
-        tracing::info!("Serving endpoints");
-        let (mut tx, rx) = mpsc::channel(8);
-        tokio::spawn(
-            async move {
-                let mut prev = HashMap::new();
-
-                while let Some(Endpoints(curr)) = endpoints_rx.recv().await {
-                    if curr.is_empty() {
-                        tx.send(Ok(pb::Update {
-                            update: Some(pb::update::Update::NoEndpoints(pb::NoEndpoints {
-                                exists: true,
-                            })),
-                        }))
-                        .await?
-                    } else {
-                        let added = curr
-                            .values()
-                            .filter(|meta| meta.is_add(&prev))
-                            .map(EndpointMeta::to_weighted_addr)
-                            .collect::<Vec<_>>();
-                        if !added.is_empty() {
-                            tracing::debug!(?added);
-
-                            let mut metric_labels = HashMap::default();
-                            metric_labels.insert("concrete".to_string(), concrete_name.clone());
-
-                            tx.send(Ok(pb::Update {
-                                update: Some(pb::update::Update::Add(pb::WeightedAddrSet {
-                                    addrs: added,
-                                    metric_labels,
-                                })),
-                            }))
-                            .await?;
-                        }
-
-                        let removed = prev
-                            .keys()
-                            .filter(|addr| !curr.contains_key(addr))
-                            .map(Into::into)
-                            .collect::<Vec<_>>();
-                        if !removed.is_empty() {
-                            tracing::debug!(?removed);
-                            tx.send(Ok(pb::Update {
-                                update: Some(pb::update::Update::Remove(pb::AddrSet {
-                                    addrs: removed,
-                                })),
-                            }))
-                            .await?;
-                        }
-                    }
-
-                    prev = curr;
-                }
-                tracing::debug!("Watch ended");
-                tx.send(Ok(pb::Update {
-                    update: Some(pb::update::Update::NoEndpoints(pb::NoEndpoints {
-                        exists: false,
-                    })),
-                }))
-                .await?;
-                Ok(())
-            }
-            .map_err(|_: mpsc::error::SendError<_>| tracing::info!("Lookup closed"))
-            .in_current_span(),
-        );
-
-        rx
-    }
-
-    #[tracing::instrument(skip(self), level = "info")]
-    async fn stream_overrides(
-        &self,
-        dst: &Dst,
-    ) -> mpsc::Receiver<GrpcResult<pb::DestinationProfile>> {
-        let mut overrides_rx = match self.inner.overrides.read().await.get(dst) {
-            Some(rx) => rx.clone(),
-            None => {
-                tracing::info!("Does not exist");
-                let (mut tx, rx) = mpsc::channel(1);
-                let _ = tx
-                    .send(Err(tonic::Status::invalid_argument("not configured")))
-                    .await;
-                return rx;
-            }
-        };
-
-        tracing::info!("Serving endpoints");
-        let (mut tx, rx) = mpsc::channel(8);
-        tokio::spawn(
-            async move {
-                while let Some(Overrides(overrides)) = overrides_rx.recv().await {
-                    tracing::debug!(?overrides);
-
-                    let dst_overrides = overrides
-                        .iter()
-                        .map(|(dst, weight)| pb::WeightedDst {
-                            authority: dst.to_string(),
-                            weight: *weight,
-                        })
-                        .collect::<Vec<_>>();
-
-                    tx.send(Ok(pb::DestinationProfile {
-                        dst_overrides,
-                        ..Default::default()
-                    }))
-                    .await?;
-                }
-                tracing::debug!("Watch ended");
-                Ok(())
-            }
-            .map_err(|_: mpsc::error::SendError<_>| tracing::info!("Lookup closed"))
-            .in_current_span(),
-        );
-
-        rx
-    }
-}
-
-#[tonic::async_trait]
-impl Destination for DstService {
-    type GetStream = mpsc::Receiver<GrpcResult<pb::Update>>;
-    type GetProfileStream = mpsc::Receiver<GrpcResult<pb::DestinationProfile>>;
-
-    async fn get(
-        &self,
-        req: tonic::Request<pb::GetDestination>,
-    ) -> GrpcResult<tonic::Response<Self::GetStream>> {
-        let pb::GetDestination { path, .. } = req.into_inner();
-        let dst = path
-            .parse()
-            .map_err(|_| tonic::Status::invalid_argument("invalid dst"))?;
-        let stream = self.stream_endpoints(&dst).await;
-        Ok(tonic::Response::new(stream))
-    }
-
-    async fn get_profile(
-        &self,
-        req: tonic::Request<pb::GetDestination>,
-    ) -> GrpcResult<tonic::Response<Self::GetProfileStream>> {
-        let pb::GetDestination { path, .. } = req.into_inner();
-        let dst = path
-            .parse()
-            .map_err(|_| tonic::Status::invalid_argument("invalid dst"))?;
-        let stream = self.stream_overrides(&dst).await;
-        Ok(tonic::Response::new(stream))
-    }
-}
-
-// === impl Dst ===
-
-impl fmt::Display for Dst {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}:{}", self.name, self.port)
-    }
-}
-
-// === impl EndpointMeta ===
-
-impl EndpointMeta {
-    fn to_weighted_addr(&self) -> pb::WeightedAddr {
-        let protocol_hint = if self.h2 {
-            Some(pb::ProtocolHint {
-                protocol: Some(pb::protocol_hint::Protocol::H2(
-                    pb::protocol_hint::H2::default(),
-                )),
-            })
-        } else {
-            None
-        };
-
-        let mut metric_labels = HashMap::default();
-        metric_labels.insert("addr".to_string(), self.address.to_string());
-        metric_labels.insert("h2".to_string(), self.h2.to_string());
-        metric_labels.extend(self.metric_labels.clone());
-
-        let ref addr = self.address;
-        pb::WeightedAddr {
-            addr: Some(addr.into()),
-            weight: self.weight,
-            protocol_hint,
-            metric_labels,
-            tls_identity: self.tls_identity.clone().map(|name| pb::TlsIdentity {
-                strategy: Some(pb::tls_identity::Strategy::DnsLikeIdentity(
-                    pb::tls_identity::DnsLikeIdentity { name },
-                )),
-            }),
-            authority_override: self
-                .authority_override
-                .clone()
-                .map(|authority_override| pb::AuthorityOverride { authority_override }),
-        }
-    }
-
-    fn is_add(&self, prev: &HashMap<SocketAddr, EndpointMeta>) -> bool {
-        match prev.get(&self.address) {
-            Some(prev_ep) => prev_ep != self,
-            None => true,
-        }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,9 +16,11 @@ use tokio::sync::{mpsc, watch, RwLock};
 use tracing_futures::Instrument;
 
 pub use self::fs_watcher::FsWatcher;
+pub use self::identity::IdentityService;
 pub use self::spec::{EndpointsSpec, OverridesSpec, ParseError};
 
 mod fs_watcher;
+mod identity;
 mod spec;
 
 pub type Error = Box<dyn std::error::Error + Send + Sync + 'static>;

--- a/src/spec.rs
+++ b/src/spec.rs
@@ -101,8 +101,8 @@ impl FromStr for Endpoints {
 
                 // Endpoints can be configured for h2 upgrading and identity with the '#' suffix:
                 // - `#h2` supports h2 upgrading
-                // - `#h2#x-identity` supports h2 upgrading and has the `x-identity` TLS identity
-                // - `##x-identity` has the `x-identity` TLS identity
+                // - `#h2#<IDENTITY>` supports h2 upgrading and has the `<IDENTITY>` TLS identity
+                // - `##<IDENTITY>` has the `<IDENTITY>` TLS identity
                 let mut parts = addr.splitn(3, '#');
                 match (parts.next(), parts.next(), parts.next()) {
                     (Some(addr), h2, identity) => match addr.parse() {
@@ -113,7 +113,7 @@ impl FromStr for Endpoints {
                                 h2: h2.map(|proto| proto == "h2").unwrap_or(false),
                                 weight: 10_000,
                                 metric_labels: BTreeMap::default(),
-                                tls_identity: identity.map(|id| id.to_owned()),
+                                tls_identity: identity.map(str::to_owned),
                                 authority_override: None,
                             },
                         )),


### PR DESCRIPTION
## Motivation

The mock destination server has been particuarly useful in benchmarking changes
to `linkerd2-proxy`. This is because a single proxy can run without needing the
`linkerd2` control plane running; it sends all destination requests to the
server and uses the responses to send requests to the correct destinations.

A current limitation is that identity must be disabled on the proxy as seen
[here](https://github.com/olix0r/l2-proxy-harness/blob/main/inc.harness.sh#L106). This is because similar to the destination service, the identity service is 
also run as part of the control plane; without that there is way to get identity
for a specific service.

## Solution

Run an identity service that returns pre-signed certificates for specific
identity names.

A new `LINKERD2_MOCK_DST_IDENTITIES_DIR` environment variable can be set which
points to a directory that contains subdirectories--each corresponding to an
identity that should be served by the identity service.

When the identity service is created, it looks at each subdirectory which should
contain at least a `crt.pem`. (It's likely that it will also contain a `csr.der`
and `key.p8` which will be used by the proxy's `ENV_IDENTITY_DIR`.)

Taking the subdirectory name as the identity name, it will serve the
certificates in `crt.pem` for that directory name.

For example, for the `foo-ns1-ca1` identity, I have directory with the
following:

```bash
:; ls /path/to/identities/
ca-config.json ca1-key.pem ca1.pem foo-ns1-ca1/

:; ls /path/to/identities/foo-ns1-ca1/
crt.pem  csr.der  key.p8
```

When a request is made for the `foo-ns1-ca1` identity, the certifcates in
`crt.pem` are returned.

## Generating files

These all contain valid values and were generated similar to the proxy's test
harness `gen-certs.sh` script.

I lean towards including this script as part of the `l2-proxy-harness` project
where these certificates, CSRs, and keys will actually be used.

## Testing

This was tested with a gRPC client that sends a `CertifyRequest` for the
`foo-ns1-ca1` identity to the identity server running locally on `:8080`.

Gist [here](https://gist.github.com/kleimkuhler/e093aca197f89a91a1016b40ef6e7210)

Signed-off-by: Kevin Leimkuhler <kevin@kleimkuhler.com>